### PR TITLE
adjust typescript definition for fromJson and fromDatabaseJson

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1529,6 +1529,10 @@ declare namespace Objection {
   }
 
   interface FromJsonMethod {
+    <M extends Model>(this: ModelClass<M>, json: object, opt?: ModelOptions): M;
+  }
+
+  interface FromDatabaseJsonMethod {
     <M extends Model>(this: ModelClass<M>, json: object): M;
   }
 
@@ -1585,7 +1589,7 @@ declare namespace Objection {
     static relationMappings: RelationMappings | RelationMappingsThunk;
 
     static fromJson: FromJsonMethod;
-    static fromDatabaseJson: FromJsonMethod;
+    static fromDatabaseJson: FromDatabaseJsonMethod;
 
     static createValidator(): Validator;
     static createValidationError(args: CreateValidationErrorArgs): Error;


### PR DESCRIPTION
Split the `FromJsonMethod` interface into `FromJsonMethod` and `FromDatabaseJsonMethod`.

The new `FromJsonMethod` parameter now accepts the additional ModelOptions argument.
The new `FromDatabaseJsonMethod` interface is the same as the old `FromJsonMethod`.